### PR TITLE
Add build CI GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,9 @@ jobs:
           rm -rf *.json *.json *.yaml *.tar.gz
       - name: Get short SHA
         id: short-sha
-        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+        run: echo "SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wfc-server-${{ steps.short-sha.outputs.sha }}
+          name: wfc-server-${{ steps.short-sha.outputs.SHA }}
           path: ./dist/*/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build CI
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install dependencies
+        run: go mod download
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete unused files
+        run: |
+          cd dist
+          rm -rf *.json *.json *.yaml *.tar.gz
+      - name: Get short SHA
+        id: short-sha
+        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wfc-server-${{ steps.short-sha.outputs.sha }}
+          path: ./dist/*/*


### PR DESCRIPTION
This PR adds a simple GitHub Actions workflow to run on push to the main branch that builds the server application for all relevant platforms using [goreleaser](https://goreleaser.com). I'm also working on getting the workflow to run properly on pull requests, but I will PR that seperately later on. The workflow publishes the built binaries in the artifacts section. Example run: [#1](https://github.com/ItsNiceCraft/wfc-server/actions/runs/7437665326).