### PR TITLE
Make all time.Now() usage UTC

### DIFF
--- a/common/auth_token.go
+++ b/common/auth_token.go
@@ -47,7 +47,7 @@ func appendString(blob []byte, value string, maxlen int) []byte {
 }
 
 func MarshalNASAuthToken(gamecd string, userid uint64, gsbrcd string, cfc uint64, region byte, lang byte, ingamesn string, unitcd byte, isLocalhost bool) (string, string) {
-	blob := binary.LittleEndian.AppendUint64([]byte{}, uint64(time.Now().Unix()))
+	blob := binary.LittleEndian.AppendUint64([]byte{}, uint64(time.Now().UTC().Unix()))
 
 	blob = appendString(blob, gamecd, 4)
 
@@ -129,7 +129,7 @@ func UnmarshalNASAuthToken(token string) (gamecd string, issuetime time.Time, us
 }
 
 func MarshalGPCMLoginTicket(profileId uint32) string {
-	blob := binary.LittleEndian.AppendUint64([]byte{}, uint64(time.Now().Unix()))
+	blob := binary.LittleEndian.AppendUint64([]byte{}, uint64(time.Now().UTC().Unix()))
 	blob = binary.LittleEndian.AppendUint32(blob, profileId)
 	blob = append(blob, loginTicketMagic...)
 

--- a/database/login.go
+++ b/database/login.go
@@ -172,7 +172,7 @@ func LoginUserToGPCM(pool *pgxpool.Pool, ctx context.Context, userId uint64, gsb
 	var bannedDeviceIdList []uint32
 	var banReason string
 
-	timeNow := time.Now()
+	timeNow := time.Now().UTC()
 	err = pool.QueryRow(ctx, SearchUserBan, user.NgDeviceId, user.ProfileId, ipAddress, *lastIPAddress, timeNow).Scan(&banExists, &banTOS, &bannedDeviceIdList, &banReason)
 
 	if err != nil {

--- a/database/user.go
+++ b/database/user.go
@@ -155,7 +155,7 @@ func ClearProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (Us
 }
 
 func BanUser(pool *pgxpool.Pool, ctx context.Context, profileId uint32, tos bool, length time.Duration, reason string, reasonHidden string, moderator string) bool {
-	_, err := pool.Exec(ctx, UpdateUserBan, profileId, time.Now(), time.Now().Add(length), reason, reasonHidden, moderator, tos)
+	_, err := pool.Exec(ctx, UpdateUserBan, profileId, time.Now().UTC(), time.Now().UTC().Add(length), reason, reasonHidden, moderator, tos)
 	return err == nil
 }
 

--- a/gamestats/auth.go
+++ b/gamestats/auth.go
@@ -70,7 +70,7 @@ func (g *GameStatsSession) authp(command common.GameSpyCommand) {
 		return
 	}
 
-	currentTime := time.Now()
+	currentTime := time.Now().UTC()
 	if issueTime.Before(currentTime.Add(-10*time.Minute)) || issueTime.After(currentTime) {
 		logging.Error(g.ModuleName, "Authtoken has expired")
 		g.Write(errorCmd)

--- a/gpcm/login.go
+++ b/gpcm/login.go
@@ -167,7 +167,7 @@ func (g *GameSpySession) login(command common.GameSpyCommand) {
 		return
 	}
 
-	currentTime := time.Now()
+	currentTime := time.Now().UTC()
 	if issueTime.Before(currentTime.Add(-10*time.Minute)) || issueTime.After(currentTime) {
 		g.replyError(ErrLoginLoginTicketExpired)
 		return

--- a/nas/auth.go
+++ b/nas/auth.go
@@ -408,6 +408,6 @@ func isValidRhgamecd(rhgamecd string) bool {
 }
 
 func getDateTime() string {
-	t := time.Now()
+	t := time.Now().UTC()
 	return fmt.Sprintf("%04d%02d%02d%02d%02d%02d", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second())
 }

--- a/nas/https.go
+++ b/nas/https.go
@@ -86,7 +86,7 @@ func startHTTPSProxy(config common.Config) {
 			go func() {
 				moduleName := "NAS-TLS:" + conn.RemoteAddr().String()
 
-				conn.SetDeadline(time.Now().Add(25 * time.Second))
+				conn.SetDeadline(time.Now().UTC().Add(25 * time.Second))
 
 				handleRealTLS(moduleName, conn, nasAddr)
 			}()
@@ -241,7 +241,7 @@ func startHTTPSProxy(config common.Config) {
 
 			moduleName := "NAS-TLS:" + conn.RemoteAddr().String()
 
-			conn.SetDeadline(time.Now().Add(5 * time.Second))
+			conn.SetDeadline(time.Now().UTC().Add(5 * time.Second))
 
 			handleTLS(moduleName, conn, nasAddr, serverCertsRecordWii, rsaKeyWii, serverCertsRecordDS, rsaKeyDS)
 		}()
@@ -316,7 +316,7 @@ func handleTLS(moduleName string, rawConn net.Conn, nasAddr string, serverCertsR
 		}
 	}
 
-	conn.SetDeadline(time.Now().Add(25 * time.Second))
+	conn.SetDeadline(time.Now().UTC().Add(25 * time.Second))
 
 	// logging.Info(moduleName, "Forwarding client hello:", aurora.Cyan(fmt.Sprintf("% X ", helloBytes)))
 	handleRealTLS(moduleName, conn, nasAddr)

--- a/nhttp/buffer.go
+++ b/nhttp/buffer.go
@@ -415,7 +415,7 @@ func (cw *chunkWriter) writeHeader(p []byte) {
 	}
 
 	//if !header.has("Date") {
-	setHeader.date = appendTime(cw.res.dateBuf[:0], time.Now())
+	setHeader.date = appendTime(cw.res.dateBuf[:0], time.Now().UTC())
 	//}
 
 	if hasCL && hasTE && te != "identity" {

--- a/nhttp/server.go
+++ b/nhttp/server.go
@@ -211,7 +211,7 @@ func (s *Server) closeIdleConns() bool {
 		// Issue 22682: treat StateNew connections as if
 		// they're idle if we haven't read the first request's
 		// header in over 5 seconds.
-		if st == _http.StateNew && unixSec < time.Now().Unix()-5 {
+		if st == _http.StateNew && unixSec < time.Now().UTC().Unix()-5 {
 			st = _http.StateIdle
 		}
 		if st != _http.StateIdle || unixSec == 0 {
@@ -385,7 +385,7 @@ func (c *conn) setState(nc net.Conn, state _http.ConnState) {
 	if state > 0xff || state < 0 {
 		panic("internal error")
 	}
-	packedState := uint64(time.Now().Unix()<<8) | uint64(state)
+	packedState := uint64(time.Now().UTC().Unix()<<8) | uint64(state)
 	c.curState.Store(packedState)
 }
 
@@ -525,7 +525,7 @@ func (c *conn) serve(ctx context.Context) {
 		}
 
 		if d := c.server.idleTimeout(); d != 0 {
-			c.rwc.SetReadDeadline(time.Now().Add(d))
+			c.rwc.SetReadDeadline(time.Now().UTC().Add(d))
 			if _, err := c.bufr.Peek(4); err != nil {
 				return
 			}
@@ -533,7 +533,7 @@ func (c *conn) serve(ctx context.Context) {
 
 		c.curReq.Store((*response)(nil))
 		if d := c.server.idleTimeout(); d != 0 {
-			c.rwc.SetReadDeadline(time.Now().Add(d))
+			c.rwc.SetReadDeadline(time.Now().UTC().Add(d))
 			if _, err := c.bufr.Peek(4); err != nil {
 				return
 			}

--- a/qr2/challenge.go
+++ b/qr2/challenge.go
@@ -54,7 +54,7 @@ func sendChallenge(conn net.PacketConn, addr net.UDPAddr, session Session, looku
 
 			mutex.Lock()
 			session, ok := sessions[lookupAddr]
-			if !ok || session.Authenticated || session.LastKeepAlive < time.Now().Unix()-60 {
+			if !ok || session.Authenticated || session.LastKeepAlive < time.Now().UTC().Unix()-60 {
 				mutex.Unlock()
 				return
 			}

--- a/qr2/group.go
+++ b/qr2/group.go
@@ -44,7 +44,7 @@ func processResvOK(moduleName string, matchVersion int, reservation common.Match
 		group = &Group{
 			GroupID:       resvOK.GroupID,
 			GroupName:     "",
-			CreateTime:    time.Now(),
+			CreateTime:    time.Now().UTC(),
 			GameName:      sender.Data["gamename"],
 			MatchType:     sender.Data["dwc_mtype"],
 			MKWRegion:     "",

--- a/qr2/main.go
+++ b/qr2/main.go
@@ -201,7 +201,7 @@ func handleConnection(conn net.PacketConn, addr net.UDPAddr, buffer []byte) {
 		// logging.Info(moduleName, "Command:", aurora.Yellow("KEEPALIVE"))
 		conn.WriteTo(createResponseHeader(KeepAliveRequest, 0), &addr)
 
-		session.LastKeepAlive = time.Now().Unix()
+		session.LastKeepAlive = time.Now().UTC().Unix()
 		return
 
 	case AvailableRequest:

--- a/qr2/session.go
+++ b/qr2/session.go
@@ -126,7 +126,7 @@ func setSessionData(moduleName string, addr net.Addr, sessionId uint32, payload 
 			Addr:            *addr.(*net.UDPAddr),
 			Challenge:       "",
 			Authenticated:   false,
-			LastKeepAlive:   time.Now().Unix(),
+			LastKeepAlive:   time.Now().UTC().Unix(),
 			Endianness:      ClientNoEndian,
 			Data:            payload,
 			PacketCount:     0,
@@ -167,7 +167,7 @@ func setSessionData(moduleName string, addr net.Addr, sessionId uint32, payload 
 	}
 
 	session.Data = payload
-	session.LastKeepAlive = time.Now().Unix()
+	session.LastKeepAlive = time.Now().UTC().Unix()
 	session.SessionID = sessionId
 	return *session, true
 }
@@ -252,7 +252,7 @@ func makeLookupAddr(addr string) uint64 {
 func GetSessionServers() []map[string]string {
 	var servers []map[string]string
 	var unreachable []uint64
-	currentTime := time.Now().Unix()
+	currentTime := time.Now().UTC().Unix()
 
 	mutex.Lock()
 	defer mutex.Unlock()


### PR DESCRIPTION
See title. Largely important for anything interacting with the DB, as time is stored without a time zone within the DB. Not sure how impactful this is elsewhere but I marked everything as UTC for consistency.

Would advise double checking things like QR2 to ensure functionality, as I'm mostly unfamiliar with that section of the project.