### PR TITLE
Add length checks to natneg handleReport and qr2 messages

### DIFF
--- a/natneg/report.go
+++ b/natneg/report.go
@@ -9,7 +9,12 @@ import (
 	"github.com/logrusorgru/aurora/v3"
 )
 
-func (session *NATNEGSession) handleReport(conn net.PacketConn, addr net.Addr, buffer []byte, _ string, version byte) {
+func (session *NATNEGSession) handleReport(conn net.PacketConn, addr net.Addr, buffer []byte, _moduleName string, version byte) {
+	if len(buffer) < 2 {
+		logging.Error(_moduleName, "Invalid packet size")
+		return
+	}
+
 	response := createPacketHeader(version, NNReportReply, session.Cookie)
 	response = append(response, buffer[:9]...)
 	response[14] = 0

--- a/qr2/message.go
+++ b/qr2/message.go
@@ -59,7 +59,7 @@ func SendClientMessage(senderIP string, destSearchID uint64, message []byte) {
 
 	// Decode and validate the message
 	isNatnegPacket := false
-	if bytes.Equal(message[:2], []byte{0xfd, 0xfc}) {
+	if len(message) >= 2 && bytes.Equal(message[:2], []byte{0xfd, 0xfc}) {
 		// Sending natneg cookie
 		isNatnegPacket = true
 		if len(message) != 0xA {
@@ -69,7 +69,7 @@ func SendClientMessage(senderIP string, destSearchID uint64, message []byte) {
 
 		natnegID := binary.LittleEndian.Uint32(message[0x6:0xA])
 		moduleName = "QR2/MSG:s" + strconv.FormatUint(uint64(natnegID), 10)
-	} else if bytes.Equal(message[:4], []byte{0xbb, 0x49, 0xcc, 0x4d}) || bytes.Equal(message[:4], []byte("SBCM")) {
+	} else if len(message) >= 4 && (bytes.Equal(message[:4], []byte{0xbb, 0x49, 0xcc, 0x4d}) || bytes.Equal(message[:4], []byte("SBCM"))) {
 		// DWC match command
 		if len(message) < 0x14 || len(message) > 0x94 {
 			logging.Error(moduleName, "Received invalid length match command packet")
@@ -219,6 +219,7 @@ func SendClientMessage(senderIP string, destSearchID uint64, message []byte) {
 		}
 	} else {
 		logging.Error(moduleName, "Invalid message:", aurora.Cyan(printHex(message)))
+		return
 	}
 
 	destSessionID, packetCount, destAddr := processClientMessage(moduleName, sender, receiver, message, isNatnegPacket, matchData)


### PR DESCRIPTION
Addresses #81 as well as another qr2 crash where qr2 messages with the incorrect length would be identified as a bad packet but then continue being processed.