### PR TITLE
Minor threading fixes and improvements

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -3,6 +3,8 @@ package common
 import (
 	"encoding/xml"
 	"os"
+
+	"github.com/sasha-s/go-deadlock"
 )
 
 type Config struct {
@@ -48,10 +50,16 @@ type Config struct {
 	ServerName string `xml:"serverName,omitempty"`
 }
 
-var config Config
-var configLoaded bool
+var (
+	config       Config
+	configLoaded bool
+	cmutex       = deadlock.Mutex{}
+)
 
 func GetConfig() Config {
+	cmutex.Lock()
+	defer cmutex.Unlock()
+
 	if configLoaded {
 		return config
 	}
@@ -127,6 +135,8 @@ func GetConfig() Config {
 	} else if config.AllowMultipleDeviceIDs != "SameIPAddress" {
 		config.AllowMultipleDeviceIDs = "never"
 	}
+
+	configLoaded = true
 
 	return config
 }

--- a/main.go
+++ b/main.go
@@ -72,6 +72,12 @@ type RPCPacket struct {
 
 // backendMain starts all the servers and creates an RPC server to communicate with the frontend
 func backendMain(noSignal, noReload bool) {
+	err := os.Mkdir("state", 0755)
+	if err != nil && !os.IsExist(err) {
+		logging.Error("BACKEN", err)
+		os.Exit(1)
+	}
+
 	sigExit := make(chan os.Signal, 1)
 	signal.Notify(sigExit, syscall.SIGINT, syscall.SIGTERM)
 

--- a/nhttp/request.go
+++ b/nhttp/request.go
@@ -218,7 +218,7 @@ type response struct {
 	// These two fields together synchronize the body reader
 	// (the expectContinueReader, which wants to write 100 Continue)
 	// against the main writer.
-	canWriteContinue atomicBool
+	canWriteContinue AtomicBool
 	writeContinueMu  sync.Mutex
 
 	w  *bufio.Writer // buffers output in chunks to chunkWriter
@@ -256,7 +256,7 @@ type response struct {
 	// written.
 	trailers []string
 
-	handlerDone atomicBool // set true when the handler exits
+	handlerDone AtomicBool // set true when the handler exits
 
 	// Buffers for Date, Content-Length, and status code
 	dateBuf   [len(TimeFormat)]byte

--- a/nhttp/response.go
+++ b/nhttp/response.go
@@ -63,7 +63,7 @@ func (w *response) sendExpectationFailed() {
 }
 
 func (w *response) finishRequest() {
-	w.handlerDone.setTrue()
+	w.handlerDone.SetTrue()
 
 	if !w.wroteHeader {
 		w.WriteHeader(_http.StatusOK)
@@ -107,9 +107,9 @@ func (w *response) WriteHeader(code int) {
 	// Handle informational headers
 	if code >= 100 && code <= 199 {
 		// Prevent a potential race with an automatically-sent 100 Continue triggered by Request.Body.Read()
-		if code == 100 && w.canWriteContinue.isSet() {
+		if code == 100 && w.canWriteContinue.IsSet() {
 			w.writeContinueMu.Lock()
-			w.canWriteContinue.setFalse()
+			w.canWriteContinue.SetFalse()
 			w.writeContinueMu.Unlock()
 		}
 
@@ -207,13 +207,13 @@ func (w *response) WriteString(data string) (n int, err error) {
 
 // either dataB or dataS is non-zero.
 func (w *response) write(lenData int, dataB []byte, dataS string) (n int, err error) {
-	if w.canWriteContinue.isSet() {
+	if w.canWriteContinue.IsSet() {
 		// Body reader wants to write 100 Continue but hasn't yet.
 		// Tell it not to. The store must be done while holding the lock
 		// because the lock makes sure that there is not an active write
 		// this very moment.
 		w.writeContinueMu.Lock()
-		w.canWriteContinue.setFalse()
+		w.canWriteContinue.SetFalse()
 		w.writeContinueMu.Unlock()
 	}
 

--- a/nhttp/server.go
+++ b/nhttp/server.go
@@ -480,7 +480,7 @@ func (c *conn) serve(ctx context.Context) {
 			if req.ProtoAtLeast(1, 1) && req.ContentLength != 0 {
 				// Wrap the Body reader with one that replies on the connection
 				req.Body = &expectContinueReader{readCloser: req.Body, resp: w}
-				w.canWriteContinue.setTrue()
+				w.canWriteContinue.SetTrue()
 			}
 		} else if req.Header.Get("Expect") != "" {
 			w.sendExpectationFailed()

--- a/qr2/main.go
+++ b/qr2/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 	"wwfc/common"
 	"wwfc/logging"
+	"wwfc/nhttp"
 
 	"github.com/logrusorgru/aurora/v3"
 )
@@ -29,7 +30,7 @@ const (
 
 var (
 	masterConn net.PacketConn
-	inShutdown = false
+	inShutdown nhttp.AtomicBool
 	waitGroup  = sync.WaitGroup{}
 )
 
@@ -44,7 +45,7 @@ func StartServer(reload bool) {
 	}
 
 	masterConn = conn
-	inShutdown = false
+	inShutdown.SetFalse()
 
 	if reload {
 		err := loadSessions()
@@ -79,7 +80,7 @@ func StartServer(reload bool) {
 		logging.Notice("QR2", "Listening on", aurora.BrightCyan(address))
 
 		for {
-			if inShutdown {
+			if inShutdown.IsSet() {
 				return
 			}
 
@@ -97,7 +98,7 @@ func StartServer(reload bool) {
 }
 
 func Shutdown() {
-	inShutdown = true
+	inShutdown.SetTrue()
 	masterConn.Close()
 	waitGroup.Wait()
 


### PR DESCRIPTION
Contains 4 fixes/improvements for threading
- Config is properly cached and locked behind a mutex as it is accessed from multiple routines at once.
- qr2 and natneg use nhttp.AtomicBool to trigger shutdown, as normal Go bools are not atomic. I doubt this impacts any legitimate behavior, but it is more correct.
- Better handling of the rpcMutex in main, primarily not accessing it without a lock on shutdown.

In addition, the state folder used for serializing connections is never generated by wwfc, so I've made that happen on backend launch. Unrelated to any other changes, I just didn't want to make another PR. If desired, I can remove the commit from this branch and create a separate PR.