### PR TITLE
Updated NAS profanity check endpoint

### DIFF
--- a/nas/auth.go
+++ b/nas/auth.go
@@ -122,7 +122,7 @@ func handleAuthRequest(moduleName string, w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		reply = handleProfanity(fields)
+		reply = handleProfanity(r.PostForm, unitcd)
 	} else if r.URL.String() == "/download" {
 		action, ok := fields["action"]
 		if !ok || action == "" {
@@ -356,9 +356,77 @@ func svcloc(fields map[string]string) map[string]string {
 	return param
 }
 
-func handleProfanity(fields map[string]string) map[string]string {
+func handleProfanity(form url.Values, unitcd string) map[string]string {
+	var wordsEncoding string
+	var wordsDefaultEncoding string
+	var wordsBytes []byte
+	var words string
+	var wordsRegion string
 	var prwords string
-	for _, word := range strings.Split(fields["words"], "\t") {
+
+	if unitcd == "0" {
+		wordsEncoding = "UTF-16LE"
+		wordsDefaultEncoding = "UTF-16LE"
+	} else {
+		wordsEncoding = "UTF-16BE"
+		wordsDefaultEncoding = "UTF-16BE"
+	}
+
+	if wencValues, ok := form["wenc"]; ok {
+		// It's okay for this to error, the real server
+		// just falls back to the default encoding in
+		// this case even if it cant properly handle it
+		wencDecoded, err := common.Base64DwcEncoding.DecodeString(wencValues[0])
+		if err == nil {
+			wordsEncoding = string(wencDecoded)
+		}
+	}
+
+	if wordsEncoding != "UTF-8" && wordsEncoding != "UTF-16LE" && wordsEncoding != "UTF-16BE" {
+		wordsEncoding = wordsDefaultEncoding
+	}
+
+	// It's okay for this to not exist/be valid, the real
+	// server will just treat the missing input as a single
+	// non-profane word
+	if wordsValues, ok := form["words"]; ok {
+		wordsDecoded, err := common.Base64DwcEncoding.DecodeString(wordsValues[0])
+		if err == nil {
+			wordsBytes = wordsDecoded
+		}
+	}
+
+	// This field is entirely optional, unsure what
+	// specifically it does. Adds extra data to the
+	// reply, probably used for handling the word
+	// list differently for different regions?
+	if wordsRegionValues, ok := form["wregion"]; ok {
+		wordsRegionDecoded, err := common.Base64DwcEncoding.DecodeString(wordsRegionValues[0])
+		if err == nil {
+			wordsRegion = string(wordsRegionDecoded)
+		}
+	}
+
+	if wordsEncoding == "UTF-8" {
+		words = string(wordsBytes)
+	} else {
+		var utf16String []uint16
+		if unitcd == "0" {
+			for i := 0; i < len(wordsBytes)/2; i++ {
+				utf16String = append(utf16String, binary.LittleEndian.Uint16(wordsBytes[i*2:i*2+2]))
+			}
+		} else {
+			for i := 0; i < len(wordsBytes)/2; i++ {
+				utf16String = append(utf16String, binary.BigEndian.Uint16(wordsBytes[i*2:i*2+2]))
+			}
+		}
+
+		words = string(utf16.Decode(utf16String))
+	}
+
+	// TODO - Handle wtype? Unsure what this field does, seems to always be an emtpy string
+
+	for _, word := range strings.Split(words, "\t") {
 		if isBadWord, _ := IsBadWord(word); isBadWord {
 			prwords += "1"
 		} else {
@@ -373,10 +441,23 @@ func handleProfanity(fields map[string]string) map[string]string {
 		returncd = "000"
 	}
 
-	return map[string]string{
+	reply := map[string]string{
 		"returncd": returncd,
 		"prwords":  prwords,
 	}
+
+	// Only known value of this field that works this way
+	if wordsRegion == "A" {
+		// TODO - The real server seems to handle the input words differently per region? These values are supposed to differ from prwords
+		reply["prwordsA"] = prwords
+		reply["prwordsC"] = prwords
+		reply["prwordsE"] = prwords
+		reply["prwordsJ"] = prwords
+		reply["prwordsK"] = prwords
+		reply["prwordsP"] = prwords
+	}
+
+	return reply
 }
 
 func dlsCount(fields map[string]string) string {


### PR DESCRIPTION
### Changes:

- Removes redundant switch-case break statements. Not strictly part of the main changes, but it cleans up the warnings thrown by [S1023](https://staticcheck.dev/docs/checks#S1023), and brings this file in line with the rest of the codebase which doesn't have these breaks
- Adds support for the `wenc` field
- Adds support for the `wregion` field
- Adds a `TODO` comment mentioning the missing `wtype` field, since its use is currently not known
- Handles missing/default fields more closely to how the real server handles them

This PR brings the NAS profanity check endpoint up to the spec documented in http://nintendo.wiki/wiki/Online/Nintendo_Network/NASC#/pr. While NASC is used by the 3DS, it is a slightly modified version of the original NAS and so the functionality should be nearly identical in this case (as far as I know Nintendo only made modifications to the actions endpoint for NASC)

I verified the functionality against both the real NASC server as well as information from the original NAS through places such as https://github.com/barronwaffles/dwc_network_server_emulator/issues/29 (which have example requests/responses from the real NAS, and it matches what I saw in NASC)