### PR TITLE
Use `wordsEncoding` for UTF16 strings when decoding profanity words

### DIFF
--- a/nas/auth.go
+++ b/nas/auth.go
@@ -411,7 +411,7 @@ func handleProfanity(form url.Values, unitcd string) map[string]string {
 		words = string(wordsBytes)
 	} else {
 		var utf16String []uint16
-		if unitcd == "0" {
+		if wordsEncoding == "UTF-16LE" {
 			for i := 0; i < len(wordsBytes)/2; i++ {
 				utf16String = append(utf16String, binary.LittleEndian.Uint16(wordsBytes[i*2:i*2+2]))
 			}


### PR DESCRIPTION
Made a mistake in https://github.com/WiiLink24/wfc-server/pull/88, I used the `unitcd` instead of `wordsEncoding` due to a bad copy-paste, my bad. This now uses the actual encoding value properly