### PR TITLE
Prevent crashing on specific heartbeat packets

### DIFF
--- a/qr2/heartbeat.go
+++ b/qr2/heartbeat.go
@@ -17,7 +17,7 @@ func heartbeat(moduleName string, conn net.PacketConn, addr net.UDPAddr, buffer 
 
 	payload := map[string]string{}
 	unknowns := []string{}
-	for i := 0; i < len(values); i += 2 {
+	for i := 0; i < len(values)-1; i += 2 {
 		if len(values[i]) == 0 || values[i][0] == '+' {
 			continue
 		}


### PR DESCRIPTION
If a heartbeat packet with an odd number of values is sent, an OOB read occurs and the server hard-crashes.

Actual POC can be provided if desired.