### PR TITLE
Fix serverbrowser crash on malformed packet

### DIFF
--- a/serverbrowser/main.go
+++ b/serverbrowser/main.go
@@ -80,6 +80,12 @@ func CloseConnection(index uint64) {
 func HandlePacket(index uint64, data []byte, address string) {
 	moduleName := "SB:" + address
 
+	defer func() {
+		if r := recover(); r != nil {
+			logging.Error(moduleName, "Panic:", r)
+		}
+	}()
+
 	mutex.RLock()
 	buffer := connBuffers[index]
 	mutex.RUnlock()

--- a/serverbrowser/server.go
+++ b/serverbrowser/server.go
@@ -336,6 +336,11 @@ func handleServerListRequest(moduleName string, connIndex uint64, address string
 
 func handleSendMessageRequest(moduleName string, connIndex uint64, address string, buffer []byte) {
 	common.MaybeUnused(connIndex)
+
+	if len(buffer) < 9 {
+		return
+	}
+
 	// Read search ID from buffer
 	searchID := uint64(binary.BigEndian.Uint32(buffer[3:7]))
 	searchID |= uint64(binary.BigEndian.Uint16(buffer[7:9])) << 32


### PR DESCRIPTION
Server browser's SendMessageRequest handler does not have appropriate length guards. A packet of

```go
bytes := []byte{
	0x00, 0x08, // Size
	0x02,                      // SendMessage Request
	0x4, 0x5, 0x6, 0x07, 0x08, // Body.
}
```

Will cause a panic.

This also adds panic recovery to server browser so other missed issues cannot take the server down.
