### PR TITLE
Validate QR2 AVAILABLE requests

### DIFF
--- a/qr2/main.go
+++ b/qr2/main.go
@@ -104,13 +104,13 @@ func StartServer(reload bool) {
 
 			buf := make([]byte, 1024)
 			n, addr, err := conn.ReadFrom(buf)
-			if err != nil || n == 0 {
+			if err != nil || n < 5 {
 				continue
 			}
 
 			waitGroup.Add(1)
 
-			go handleConnection(conn, *addr.(*net.UDPAddr), buf)
+			go handleConnection(conn, *addr.(*net.UDPAddr), buf, n)
 		}
 	}()
 }
@@ -145,7 +145,7 @@ func Shutdown() {
 	logging.Notice("QR2", "Saved", aurora.Cyan(len(groups)), "groups")
 }
 
-func handleConnection(conn net.PacketConn, addr net.UDPAddr, buffer []byte) {
+func handleConnection(conn net.PacketConn, addr net.UDPAddr, buffer []byte, n int) {
 	defer waitGroup.Done()
 
 	packetType := buffer[0]
@@ -224,6 +224,19 @@ func handleConnection(conn net.PacketConn, addr net.UDPAddr, buffer []byte) {
 		return
 
 	case AvailableRequest:
+		// Expect a null terminated string
+		if buffer[n-1] != 0 {
+			return
+		}
+
+		// Only respond if the game name provided in the packet is valid
+		gameName := string(buffer[5 : n-1])
+		gameInfo := common.GetGameInfoByName(gameName)
+
+		if gameInfo == nil {
+			return
+		}
+
 		logging.Info("QR2", "Command:", aurora.Yellow("AVAILABLE"))
 		_, _ = conn.WriteTo(createResponseHeader(AvailableRequest, 0), &addr)
 		return


### PR DESCRIPTION
Currently the handler for qr2 AVAILABLE does not have any checks for the validity. The packet is supposed to include a valid null-terminated game name, which this PR adds a check for.

Tested via https://github.com/ppebb/wfc-server-testing/blob/main/qr2.go#L11.